### PR TITLE
Board feat/rendering

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -76,4 +76,18 @@ class Board
       false
     end
   end
+
+  def render(debug = false)
+    cell_render = []
+
+    @cells.values.each do |cell|
+      cell_render << cell.render(debug)
+    end
+    
+    "  1 2 3 4 \n" +
+    "A #{cell_render[0]} #{cell_render[1]} #{cell_render[2]} #{cell_render[3]} \n" +
+    "B #{cell_render[4]} #{cell_render[5]} #{cell_render[6]} #{cell_render[7]} \n" +
+    "C #{cell_render[8]} #{cell_render[9]} #{cell_render[10]} #{cell_render[11]} \n" +
+    "D #{cell_render[12]} #{cell_render[13]} #{cell_render[14]} #{cell_render[15]} \n"
+  end
 end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -40,7 +40,6 @@ class Cell
   end
 
   def render(debug = false)
-    debug = debug
     if !fired_upon? && !@ship.nil? && debug
       "S"
     elsif !fired_upon?

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -126,4 +126,30 @@ RSpec.describe Board do
       expect(cell_3.ship).to be nil
     end
   end
+
+  describe "#render" do
+    it "will return a readable board output made of strings" do
+      board = Board.new
+      expect(board.render).to eq(
+        "  1 2 3 4 \n" +
+        "A . . . . \n" +
+        "B . . . . \n" +
+        "C . . . . \n" +
+        "D . . . . \n"
+      )
+    end
+
+    it 'can show locations of ships using optional argument' do
+      board = Board.new
+      cruiser = Ship.new("Cruiser", 3)
+      board.place(cruiser, ["A1", "A2", "A3"])
+      expect(board.render(true)).to eq(
+        "  1 2 3 4 \n" +
+        "A S S S . \n" +
+        "B . . . . \n" +
+        "C . . . . \n" +
+        "D . . . . \n"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Wrote a method called #render that allows the board to format a readable string output of all its cells
This method has an optional argument that allows the board to show ships that have not been hit yet in the format